### PR TITLE
Add dir option in most commands for ad-hoc processing

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         # install monetdb
         export lsbrelease=$(lsb_release -cs)
         sudo sh -c "echo 'deb http://dev.monetdb.org/downloads/deb/ ${lsbrelease} monetdb' > /etc/apt/sources.list.d/monetdb.list"
-        sudo sh -c "echo 'deb-src https://dev.monetdb.org/downloads/deb/ bionic ${lsbrelease} >> /etc/apt/sources.list.d/monetdb.list"
+        sudo sh -c "echo 'deb-src https://dev.monetdb.org/downloads/deb/ ${lsbrelease} monetdb' >> /etc/apt/sources.list.d/monetdb.list"
         wget --output-document=- http://dev.monetdb.org/downloads/MonetDB-GPG-KEY | sudo apt-key add -
         sudo apt-get update -q
         sudo apt-get install -qy monetdb5-sql monetdb-client

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2
@@ -26,8 +26,9 @@ jobs:
     - name: set monetdb
       run: |
         # install monetdb
-        sudo sh -c "echo 'deb http://dev.monetdb.org/downloads/deb/ bionic monetdb' > /etc/apt/sources.list.d/monetdb.list"
-        sudo sh -c "echo 'deb-src https://dev.monetdb.org/downloads/deb/ bionic monetdb' >> /etc/apt/sources.list.d/monetdb.list"
+        lsbrelease=$(lsb_release -cs)
+        sudo sh -c "echo 'deb http://dev.monetdb.org/downloads/deb/ ${lsbrelease} monetdb' > /etc/apt/sources.list.d/monetdb.list"
+        sudo sh -c "echo 'deb-src https://dev.monetdb.org/downloads/deb/ bionic ${lsbrelease} >> /etc/apt/sources.list.d/monetdb.list"
         wget --output-document=- http://dev.monetdb.org/downloads/MonetDB-GPG-KEY | sudo apt-key add -
         sudo apt-get update -q
         sudo apt-get install -qy monetdb5-sql monetdb-client

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,7 +26,7 @@ jobs:
     - name: set monetdb
       run: |
         # install monetdb
-        lsbrelease=$(lsb_release -cs)
+        export lsbrelease=$(lsb_release -cs)
         sudo sh -c "echo 'deb http://dev.monetdb.org/downloads/deb/ ${lsbrelease} monetdb' > /etc/apt/sources.list.d/monetdb.list"
         sudo sh -c "echo 'deb-src https://dev.monetdb.org/downloads/deb/ bionic ${lsbrelease} >> /etc/apt/sources.list.d/monetdb.list"
         wget --output-document=- http://dev.monetdb.org/downloads/MonetDB-GPG-KEY | sudo apt-key add -

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ farmdown:
 	fi
 
 .PHONY: clean
-clean: 
+clean: farmdown
 	if [[ -d ${DB_FARM} ]];then\
 		rm -r ${DB_FARM};\
 	fi

--- a/mroll/commands.py
+++ b/mroll/commands.py
@@ -183,7 +183,8 @@ def applied_revisions(show_patch=False, mdir=None):
     lookup = {}
     for r in migr_ctx.revisions:
         lookup[r.id] = r
-    working_set: List[Revision] = list(filter(lambda rev: lookup.get(rev.id, None) is not None, wd.revisions))
+
+    working_set: List[Revision] = list(filter(lambda rev: rev.id in lookup, wd.revisions))
     for rev in working_set:
         if show_patch:
             print(rev.serialize())
@@ -204,7 +205,8 @@ def pending_revisions(show_patch=False, mdir=None):
     lookup = {}
     for r in migr_ctx.revisions:
         lookup[r.id] = r
-    working_set: List[Revision] = list(filter(lambda rev: lookup.get(rev.id, None) is None, wd.revisions))
+
+    working_set: List[Revision] = list(filter(lambda rev: rev.id not in lookup, wd.revisions))
     for r in working_set:
         if show_patch:
             print(r.serialize())

--- a/mroll/commands.py
+++ b/mroll/commands.py
@@ -45,7 +45,7 @@ def ensure_init():
 
 # ----------------------------------
 
-@click.group(chain=True)
+@click.group()
 @click.pass_context
 def cli(ctx):
     ctx.ensure_object(dict)
@@ -213,34 +213,36 @@ def pending_revisions(show_patch=False, mdir=None):
         else:
             print(r)
 
-@cli.command(name="show")
-@click.argument('subcmd', nargs=1)
-@click.argument('options', required=False)
+@cli.group(name="show")
+def show():
+    pass
+
+@show.command(name="all")
+@click.option('-p', '--patch', is_flag=True)
 @click.option('-d', '--dir', 'mdir', help="the migrations directory")
-def show(subcmd, options, mdir):
-    """
-    Shows revisions information.\n
-    mroll show [ all | pending | applied ] [-p|--patch]
-    """
+def all(patch, mdir):
     if not mdir:
         ensure_init()
-    def usage(err_msg: str):
-        res ="Error: {}\n".format(err_msg) if err_msg else ''
-        res += 'Usage:\n'
-        res+='mroll show [pending|applied|all] [-p|--patch]\n'
-        return res
-    show_patch = False
-    if subcmd not in ['all', 'pending', 'applied']:
-        raise SystemExit(usage("Invalid subcommand!"))
-    if options:
-        if options not in ['-p', '--p']:
-            raise SystemExit(usage("Invalid subcommand option!"))
-        show_patch = True 
-    if subcmd == 'pending':
-        return pending_revisions(show_patch=show_patch, mdir=mdir)
-    if subcmd == 'applied':
-        return applied_revisions(show_patch=show_patch, mdir=mdir)
-    return all_revisions(show_patch=show_patch, mdir=mdir)
+
+    return all_revisions(show_patch=patch, mdir=mdir)
+
+@show.command(name="pending")
+@click.option('-p', '--patch', is_flag=True)
+@click.option('-d', '--dir', 'mdir', help="the migrations directory")
+def pending(patch, mdir):
+    if not mdir:
+        ensure_init()
+
+    return pending_revisions(show_patch=patch, mdir=mdir)
+
+@show.command(name="applied")
+@click.option('-p', '--patch', is_flag=True)
+@click.option('-d', '--dir', 'mdir', help="the migrations directory")
+def applied(patch, mdir):
+    if not mdir:
+        ensure_init()
+
+    return applied_revisions(show_patch=patch, mdir=mdir)
 
 @cli.command(name="upgrade")
 @click.option('-n', '--num', 'step', help="run n number of pending revisions")

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
 from .test_commands import *
 from .test_work_dir import *
 from .test_migration_context import *
+from .test_ad_hoc import *

--- a/tests/data/mroll.ini
+++ b/tests/data/mroll.ini
@@ -1,0 +1,11 @@
+[db]
+db_name=mroll_test_db
+username=monetdb
+password=monetdb
+
+[host]
+hostname=127.0.0.1
+port=50000
+
+[mroll]
+rev_history_tbl_name = mroll_revisions

--- a/tests/data/versions/6c163e323a89_test_revision_0.sql
+++ b/tests/data/versions/6c163e323a89_test_revision_0.sql
@@ -4,5 +4,9 @@
 -- ts=2022-11-25T18:25:16.940894
 -- migration:upgrade
 
+create table test.revision0 (i int);
+insert into test.revision0 values (1), (2);
+
 -- migration:downgrade
 
+drop table test.revision0;

--- a/tests/data/versions/6c163e323a89_test_revision_0.sql
+++ b/tests/data/versions/6c163e323a89_test_revision_0.sql
@@ -1,0 +1,8 @@
+-- identifiers used by mroll
+-- id=6c163e323a89
+-- description=test revision 0
+-- ts=2022-11-25T18:25:16.940894
+-- migration:upgrade
+
+-- migration:downgrade
+

--- a/tests/test_ad_hoc.py
+++ b/tests/test_ad_hoc.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+import shutil
+from tempfile import mkdtemp
+import unittest
+
+from click.testing import CliRunner
+
+from mroll.commands import *
+
+class TestAdHoc(unittest.TestCase):
+    def setUp(self):
+        self.work_dir = mkdtemp()
+        self.work_path = Path(self.work_dir)
+        v = self.work_path / 'versions'
+        v.mkdir()  # create versions directory
+        self.db_name = os.environ.get('TEST_DB_NAME', 'mroll_test_db')
+
+    def tearDown(self):
+        if os.path.exists(self.work_dir):
+            shutil.rmtree(self.work_dir)
+
+    def test_revision(self):
+        runner = CliRunner()
+        r = runner.invoke(revision, ['-m', 'test-revision', '-d', self.work_dir])
+        self.assertEqual(r.exit_code, 0)   # mroll revision ran correctly
+        ln = list(self.work_path.rglob('*test-revision*'))
+        self.assertEqual(len(ln), 1)   # it created one file that matches the glob *test-revision*

--- a/tests/test_ad_hoc.py
+++ b/tests/test_ad_hoc.py
@@ -5,16 +5,30 @@ from tempfile import mkdtemp
 import unittest
 
 from click.testing import CliRunner
+import pymonetdb
 
 from mroll.commands import *
+
+# The idea for the ad-hoc commands is that we have already a database
+# that has some migrations applied and a non-empty migrations
+# directory.  The use case is the re-deployment of a service that uses
+# mroll. We clone the service's source code, we restore the database
+# from a backup and we need to apply any migrations that have been
+# added since last time. This usually fails because `mroll setup` has
+# not been ran, and when we run it, it fails with the error that the
+# `migrations` directory is not empty.
 
 class TestAdHoc(unittest.TestCase):
     def setUp(self):
         self.work_dir = mkdtemp()
         data_dir = Path(__file__).parent / "data"
-        shutil.copy2(data_dir, self.work_dir)
+        shutil.copytree(data_dir, self.work_dir, dirs_exist_ok=True)
         self.work_path = Path(self.work_dir)
         self.db_name = 'mroll_test_db'
+        conn = pymonetdb.connect(self.db_name)
+        conn.execute("create schema if not exists test")
+        conn.execute("create table if not exists sys.mroll_revisions(id string primary key, description string, ts timestamp)")
+        conn.commit()
 
     def tearDown(self):
         if os.path.exists(self.work_dir):
@@ -22,10 +36,30 @@ class TestAdHoc(unittest.TestCase):
 
     def test_revision(self):
         runner = CliRunner()
-        r = runner.invoke(revision, ['-m', 'test-revision', '-d', self.work_dir])
-        self.assertEqual(r.exit_code, 0)   # mroll revision ran correctly
+        res = runner.invoke(revision, ['-m', 'test-revision', '-d', self.work_dir])
+        self.assertEqual(res.exit_code, 0)   # mroll revision ran correctly
         ln = list(self.work_path.rglob('*test-revision*'))
         self.assertEqual(len(ln), 1)   # it created one file that matches the glob *test-revision*
 
+    def test_upgrade(self):
+        runner = CliRunner()
+        res = runner.invoke(upgrade, ['-d', self.work_path])
+        self.assertEqual(res.exit_code, 0)
+
+        # make sure that the SQL commands in the revision had an
+        # effect.
+        conn = pymonetdb.connect(self.db_name)
+        cur = conn.cursor()
+        cur.execute("select * from test.revision0")
+        r = cur.fetchall()
+        self.assertEqual(len(r), 2)
+
     def test_history(self):
-        pass
+        runner = CliRunner()
+        res = runner.invoke(upgrade, ['-d', self.work_path])
+        self.assertEqual(res.exit_code, 0)
+        res = runner.invoke(history, ['-d', self.work_path])
+        self.assertEqual(res.exit_code, 0)
+        # count the lines in the output
+        self.assertEqual(res.output.count("\n"), 1)
+        self.assertTrue("test revision 0" in res.output)

--- a/tests/test_ad_hoc.py
+++ b/tests/test_ad_hoc.py
@@ -11,10 +11,10 @@ from mroll.commands import *
 class TestAdHoc(unittest.TestCase):
     def setUp(self):
         self.work_dir = mkdtemp()
+        data_dir = Path(__file__).parent / "data"
+        shutil.copy2(data_dir, self.work_dir)
         self.work_path = Path(self.work_dir)
-        v = self.work_path / 'versions'
-        v.mkdir()  # create versions directory
-        self.db_name = os.environ.get('TEST_DB_NAME', 'mroll_test_db')
+        self.db_name = 'mroll_test_db'
 
     def tearDown(self):
         if os.path.exists(self.work_dir):
@@ -26,3 +26,6 @@ class TestAdHoc(unittest.TestCase):
         self.assertEqual(r.exit_code, 0)   # mroll revision ran correctly
         ln = list(self.work_path.rglob('*test-revision*'))
         self.assertEqual(len(ln), 1)   # it created one file that matches the glob *test-revision*
+
+    def test_history(self):
+        pass


### PR DESCRIPTION
The idea is to avoid having to run `mroll setup`. These changes allow the user to explicitly pass the migrations directory with most mroll commands. 

Having to run setup is very inconvenient when restoring the database from a backup but there are more migrations to run. This is the most frequent usecase in workbench production.

Note that I have tested the upgrade command, but not the rest. I will in the next few days and push any changes here.